### PR TITLE
disable "monochrome" options because it causes some syntax errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .gradle/
 gradle.properties
 bin/*.jar
+out/

--- a/src/main/kotlin/com/bitjourney/plantuml/Main.kt
+++ b/src/main/kotlin/com/bitjourney/plantuml/Main.kt
@@ -74,7 +74,8 @@ class Main {
         json.toString().toByteArray(Charsets.UTF_8)
     }
 
-    val defaultConfig = Arrays.asList("skinparam monochrome true")
+    // NOTE: Remove "skinparam monochrome true" for a while because it lets "SALT" to cause errors :(
+    val defaultConfig:List<String> = Arrays.asList()
 
     val outputFormat = FileFormatOption(FileFormat.SVG, true)
 

--- a/src/test/kotlin/com/bitjourney/plantuml/MainTest.kt
+++ b/src/test/kotlin/com/bitjourney/plantuml/MainTest.kt
@@ -8,7 +8,7 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class MainTest {
     @Test
-    fun render() {
+    fun renderSequenceDiagram() {
         val main = Main()
 
         val source = """
@@ -25,5 +25,46 @@ class MainTest {
 
         assertThat(result).contains("Alice")
         assertThat(result).contains("Bob")
+        assertThat(result).doesNotContain("Syntax error")
+    }
+
+    @Test
+    fun renderSalt() {
+        val main = Main()
+
+        val source = """
+            @startuml
+            salt
+            {
+              Just plain text
+              [This is my button]
+              ()  Unchecked radio
+              (X) Checked radio
+              []  Unchecked box
+              [X] Checked box
+              "Enter text here   "
+              ^This is a droplist^
+            }
+            @enduml
+        """
+
+        val result = main.render(DataSource(source, main.defaultConfig)).toString(Charsets.UTF_8)
+
+        assertThat(result).doesNotContain("Syntax error")
+    }
+
+    @Test
+    fun renderVersion() {
+        val main = Main()
+
+        val source = """
+            @startuml
+            version
+            @enduml
+        """
+
+        val result = main.render(DataSource(source, main.defaultConfig)).toString(Charsets.UTF_8)
+
+        assertThat(result).doesNotContain("Syntax error")
     }
 }


### PR DESCRIPTION
`skinparam` causes syntax errors if the code includes SALT: http://plantuml.com/salt 😞 