### PR TITLE
Upgrade docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# https://hub.docker.com/_/openjdk/
-FROM openjdk:8
+# https://hub.docker.com/_/eclipse-temurin?tab=description&page=2&name=17
+FROM eclipse-temurin:17
 
 ARG PLANTUML_SERVICE_VERSION
 ARG PLANTUML_SERVICE_JAR_URL="https://github.com/bitjourney/plantuml-service/releases/download/v${PLANTUML_SERVICE_VERSION}/plantuml-service.jar"
@@ -22,5 +22,5 @@ RUN useradd --create-home app \
 
 USER app
 
-ENTRYPOINT ["/usr/bin/java"]
+ENTRYPOINT ["/opt/java/openjdk/bin/java"]
 CMD ["-jar", "/home/app/plantuml-service/bin/plantuml-service.jar"]


### PR DESCRIPTION
# summary

Upgrade the docker base image.

# Why change it?

## Bump dependencies

Bump dependencies and use java 17.
https://github.com/bitjourney/plantuml-service/pull/48

## Base image is deprecated

openjdk_8 is now deprecated.
https://hub.docker.com/_/openjdk/

> This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. Some examples of other Official Image alternatives (listed in alphabetical order with no intentional or implied preference):
[amazoncorretto](https://hub.docker.com/_/amazoncorretto)
[eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)
[ibm-semeru-runtimes](https://hub.docker.com/_/ibm-semeru-runtimes)
[ibmjava](https://hub.docker.com/_/ibmjava)
[sapmachine](https://hub.docker.com/_/sapmachine)
See [docker-library/openjdk#505](https://github.com/docker-library/openjdk/issues/505) for more information.
The only tags which will continue to receive updates beyond July 2022 will be Early Access builds (which are sourced from [jdk.java.net](https://jdk.java.net/)), as those are not published/supported by any of the above projects.

# details

I choise the images of eclipse-temurin, because it not depends on identification platform.
ex) amazoncorretto is for aws-service

However, I don't have any strong opinion about it, so if you have any images to recommend, let me know.

ref) https://future-architect.github.io/articles/20211220a/
