### PR TITLE
Add GitHub Actions workflow for building Docker image and checking artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build Docker image for building
+      run: docker build -f DockerfileForBuild -t plantuml-service-builder .
+
+    - name: Run build
+      run: docker run --rm -v $(pwd):/app plantuml-service-builder ./gradlew stage
+
+    - name: Check build artifacts
+      run: |
+        if [ ! -f "./bin/plantuml-service.jar" ]; then
+          echo "Build failed: JAR file not found"
+          exit 1
+        fi
+        echo "Build successful: JAR file created"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build process for the project. The workflow ensures that the build artifacts are correctly generated and validates the success of the build.

### CI/CD Automation:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R26): Added a new GitHub Actions workflow named `Build` triggered on pull requests to the `master` branch. The workflow builds a Docker image (`DockerfileForBuild`), runs the build inside the container using Gradle (`./gradlew stage`), and checks for the presence of the `plantuml-service.jar` artifact to confirm the build's success.