### PR TITLE
fix: resolve Gradle permission error in GitHub Actions release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,7 @@ jobs:
     - name: Run release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew release
+        GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
+      run: |
+        mkdir -p .gradle
+        ./gradlew release


### PR DESCRIPTION
Set GRADLE_USER_HOME environment variable to place Gradle cache directory
within the workspace to fix permission denied errors
