### PR TITLE
fix: resolve Gradle permission issues in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       run: docker build -f DockerfileForBuild -t plantuml-service-builder .
 
     - name: Run build
-      run: docker run --rm -v $(pwd):/app plantuml-service-builder ./gradlew stage
+      run: docker run --rm -v $(pwd):/app -e GRADLE_USER_HOME=/app/.gradle plantuml-service-builder ./gradlew stage
 
     - name: Check build artifacts
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       run: docker build -f DockerfileForBuild -t plantuml-service-builder .
 
     - name: Run build
-      run: docker run --rm -v $(pwd):/app plantuml-service-builder ./gradlew stage
+      run: docker run --rm -v $(pwd):/app -e GRADLE_USER_HOME=/app/.gradle plantuml-service-builder ./gradlew stage
 
     - name: Check build artifacts
       run: |
@@ -52,4 +52,5 @@ jobs:
         GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
       run: |
         mkdir -p .gradle
+        chmod -R 755 .gradle
         ./gradlew release


### PR DESCRIPTION
- Set GRADLE_USER_HOME environment variable for Docker container builds
- Configure GRADLE_USER_HOME for release job with proper directory permissions
- Apply fix to both build.yml and release.yml workflows
