### PR TITLE
fix: Release Pleaseのversioning設定をalways-bump-patchに修正

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "simple",
-      "versioning": "always-patch",
+      "versioning": "always-bump-patch",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
## Summary

Fixes the Release Please versioning configuration by using the correct strategy name.

**Background**: PR #232 introduced `versioning: "always-patch"` which is not a valid Release Please strategy, causing the release workflow to fail.

## Changes

Changed `versioning` value from `always-patch` to `always-bump-patch`.

### Changed Files
| File | Description |
|------|-------------|
| release-please-config.json | Fix versioning strategy value |

## Impact & Considerations

- Fixes the Release Please workflow failure
- After merging, Release Please will correctly bump only patch versions

## Verification

- [ ] Release Please workflow succeeds after merge