### PR TITLE
fix: release-pleaseがリリースPRを作成できるように修正

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,10 +18,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # GitHubリリースの作成はgradleに任せる
-          skip-github-release: true
 
-      # リリースPRがマージされたら、既存のReleaseワークフローを実行
       - name: Trigger Release workflow
         if: ${{ steps.release.outputs.releases_created }}
         run: gh workflow run release.yml --ref master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,18 +43,12 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Release version: $VERSION"
 
-    - name: Build Docker image for release
-      run: docker build -f DockerfileForRelease -t plantuml-service-releaser .
-
-    - name: Create GitHub Release with Docker
+    - name: Upload JAR to GitHub Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        docker run --rm \
-          -e GITHUB_OAUTH=$GITHUB_TOKEN \
-          -e GITHUB_TOKEN=$GITHUB_TOKEN \
-          -v $(pwd):/app \
-          plantuml-service-releaser ./gradlew release
+        VERSION=$(grep "^version " build.gradle | cut -d "'" -f 2)
+        gh release upload "v${VERSION}" ./bin/plantuml-service.jar --clobber
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3


### PR DESCRIPTION
## 概要

release-pleaseがv1.4.27以降リリースPRを作成できなくなっていた問題を修正。

`skip-github-release: true` により、release-please自身がGitHub Releaseを作成しないため、マージ済みPR #234を「未完了」と判定して新規PR作成がブロックされていた。

## 変更点

- release-please自身がGitHub Releaseを作成するように `skip-github-release: true` を削除
- release.ymlからgradleによるGitHub Release作成（DockerfileForRelease経由）を削除し、`gh release upload`でJARアセットのみアップロードするように変更
- PR #234のラベルを `autorelease: pending` → `autorelease: tagged` に変更済み（ブロック解消）

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `.github/workflows/release-please.yml` | `skip-github-release: true` を削除 |
| `.github/workflows/release.yml` | gradleリリースをgh release uploadに置換 |

## 影響範囲・懸念点

- v1.4.28以降、GitHub Releaseはrelease-pleaseが作成するため、リリースノートのフォーマットがCHANGELOGベースに変わる
- `DockerfileForRelease` と `release.gradle` は不要になるが、このPRでは削除していない（必要であれば別PRで対応）

## 動作確認方法

- [ ] masterにマージ後、release-pleaseが新しいリリースPR（v1.4.28）を自動作成することを確認