### PR TITLE
fail tests on stderr

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,13 @@ jar {
     exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
 }
 
+test {
+    testLogging {
+        events "passed", "skipped", "failed", "standard_out", "standard_error"
+        showStandardStreams = true
+    }
+}
+
 task stage(type: Copy, dependsOn: jar) {
     from file("build/libs/${ArchiveName}")
     into file("bin/")

--- a/src/test/kotlin/com/bitjourney/plantuml/MainTest.kt
+++ b/src/test/kotlin/com/bitjourney/plantuml/MainTest.kt
@@ -1,12 +1,44 @@
 package com.bitjourney.plantuml
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.io.PrintStream
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class MainTest {
+
+    private val originalErr: PrintStream = System.err
+    private val errCapture = ByteArrayOutputStream()
+
+    @Before
+    fun captureStderr() {
+        val tee = object : OutputStream() {
+            override fun write(b: Int) {
+                originalErr.write(b)
+                errCapture.write(b)
+            }
+
+            override fun write(b: ByteArray, off: Int, len: Int) {
+                originalErr.write(b, off, len)
+                errCapture.write(b, off, len)
+            }
+        }
+        System.setErr(PrintStream(tee, true, Charsets.UTF_8))
+    }
+
+    @After
+    fun verifyStderr() {
+        System.setErr(originalErr)
+        val stderr = errCapture.toString(Charsets.UTF_8)
+        assertThat(stderr).doesNotContain("Exception")
+        assertThat(stderr).doesNotContain("Error")
+    }
 
     @Test
     fun renderSequenceDiagram() {


### PR DESCRIPTION
## Summary
- Fail tests when any exception or error stack trace is written to `System.err`. Previously, PlantUML would swallow internal exceptions and return a fallback "Welcome to PlantUML!" SVG, so the tests passed even when rendering had actually failed.
- Capture `System.err` via a tee stream in `@Before` (preserving CI log output) and assert in `@After` that the captured stderr does not contain `Exception` or `Error`.
- Enable Gradle `testLogging` for `passed`, `skipped`, `failed`, `standard_out`, and `standard_error` events so per-test results and stdout/stderr are visible in CI logs.

## Test plan
- [ ] Confirm CI surfaces individual test results (passed/failed) and standard streams in the workflow log
- [ ] Confirm a test that triggers an internal PlantUML exception now fails instead of silently passing