### PR TITLE
kuroponzu/upgrade PlantUmlVersion 202606

### DIFF
--- a/DockerfileForBuild
+++ b/DockerfileForBuild
@@ -1,7 +1,8 @@
-# Build-only environment for plantuml-service
+# Build and test environment for plantuml-service
 # Usage:
 # 1. Build the image: docker build -f DockerfileForBuild -t plantuml-service-builder .
-# 2. Run the container to build: docker run --rm -v $(pwd):/app plantuml-service-builder ./gradlew stage
+# 2. Run the container to test: docker run --rm -v $(pwd):/app plantuml-service-builder ./gradlew test
+# 3. Run the container to build: docker run --rm -v $(pwd):/app plantuml-service-builder ./gradlew stage
 # The built JAR will be available in the ./bin directory
 
 FROM eclipse-temurin:17.0.15_6-jdk-jammy

--- a/DockerfileForBuild
+++ b/DockerfileForBuild
@@ -9,7 +9,7 @@ FROM eclipse-temurin:17.0.15_6-jdk-jammy
 
 RUN apt-get update -qq \
     && apt-get upgrade -y \
-    && apt-get install -y curl unzip \
+    && apt-get install -y curl unzip graphviz \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ final MainClassName = "${group}.Main"
 // See
 // http://plantuml.com/changes
 // https://search.maven.org/artifact/net.sourceforge.plantuml/plantuml
-final PlantUmlVersion = "1.2026.5"
+final PlantUmlVersion = "1.2026.6"
 
 final ArchiveName = "plantuml-service.jar"
 

--- a/src/test/kotlin/com/bitjourney/plantuml/MainTest.kt
+++ b/src/test/kotlin/com/bitjourney/plantuml/MainTest.kt
@@ -100,4 +100,25 @@ class MainTest {
 
         assertThat(result).doesNotContain("Syntax error")
     }
+
+    @Test
+    fun renderAWSIcon() {
+        val main = Main()
+
+        val source = """
+            @startuml
+            !define AWSPuml https://raw.githubusercontent.com/awslabs/aws-icons-for-plantuml/v23.0/dist
+            !include AWSPuml/AWSCommon.puml
+            !include AWSPuml/Compute/Lambda.puml
+            !include AWSPuml/Storage/SimpleStorageService.puml
+            Lambda(fn, "Function", "function")
+            SimpleStorageService(s3, "S3", "storage")
+            fn --> s3
+            @enduml
+        """
+
+        val result = main.render(DataSource(source, main.fileFormat)).toString(Charsets.UTF_8)
+        assertThat(result).contains("Function")
+        assertThat(result).contains("S3")
+    }
 }


### PR DESCRIPTION
## Summary
- Upgrade PlantUML from `1.2026.5` to `1.2026.6`. The previous version threw `IndexOutOfBoundsException` while parsing AWS icon `!include` directives, which caused the diagram to fall back to the default "Welcome to PlantUML!" SVG.
- Add a `renderAWSIcon` test that renders an AWS icon diagram (Lambda + S3) and asserts the resulting SVG actually contains the icon labels, so that this regression is detected if it returns.
- Install `graphviz` in `DockerfileForBuild` so the `dot` executable is available during tests; AWS icon rendering requires Graphviz.
- Update the `DockerfileForBuild` header comment to reflect that the image is now used for both testing and building.
