### PR TITLE
fix(ci): trigger release workflow only when a new tag is created

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger Release workflow
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.tag_name }}
         run: gh workflow run release.yml --ref master
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously, the trigger used `steps.release.outputs.releases_created`
which returned a truthy value even when release-please only reported
an existing release. As a result, release.yml ran on every push to
master, re-uploading the same JAR and re-pushing the same Docker image.

Switch the condition to `steps.release.outputs.tag_name`, which is
only set when release-please actually creates a new release tag.
